### PR TITLE
check template argument length

### DIFF
--- a/rillc/src/sema_construct_env.ml
+++ b/rillc/src/sema_construct_env.ml
@@ -2759,6 +2759,9 @@ and prepare_instantiate_template t_env_record template_args ext_env ctx attr =
     | _ -> failwith "[ICE] unexpected template params"
   in
 
+  if (List.length template_params) < (List.length template_args) then
+    raise Instantiation_failed;
+
   (* In this context, value of MetaVar is treated as TYPE *)
 
   (* *)

--- a/test/compilable/template_arg_length_check.rill
+++ b/test/compilable/template_arg_length_check.rill
@@ -1,0 +1,15 @@
+import std.stdio;
+
+def f!(N: int32)() {
+    N.print();
+}
+def f!(N: int32, M: int32)() {
+    N.print();
+    M.print();
+}
+
+def main() {
+    f!(42)();
+    f!(10, 20)();
+    return 0;
+}


### PR DESCRIPTION
I think that the sample code below should cause compilation error
but it is compiled successfully.

```
def f!(N: int32)() {
}

def main() {
    f!(10, 20)();
}
```

So, check to ensure that template argument length is less than or equal to
template parameter length.