### PR TITLE
Fix compilation error that occurs when postfix operator is used

### DIFF
--- a/rillc/src/parser.mly
+++ b/rillc/src/parser.mly
@@ -669,6 +669,12 @@ postfix_expression:
                 { Ast.SubscriptingExpr ($1, $3, pos $startpos($2) $endpos($4)) }
         |       traits_expression { $1 }
         |       call_expression { $1 }
+        |       postfix_expression op = unary_operator_as_raw
+                {
+                    let op_id =
+                        Ast.Id (Nodes.UnaryPostOp op, pos $startpos(op) $endpos(op)) in
+                    Ast.UnaryOpExpr (op_id, $1, pos $startpos $endpos)
+                }
 
 call_expression:
                 postfix_expression argument_list

--- a/test/compilable/postfix_operator.rill
+++ b/test/compilable/postfix_operator.rill
@@ -1,0 +1,12 @@
+import std.stdio;
+
+class C {
+    def operator post++() {
+        "operator post++\n".print();
+    }
+}
+
+def main() {
+    val mutable c = C();
+    c++;
+}


### PR DESCRIPTION
The postfix operator(++, --) could be defined but could not be used.
So, add postfix operator to postfix-expression of the syntax rule.