### PR TITLE
Fix compilation error that occurs when prefix operator '-' is defined

### DIFF
--- a/rillc/src/parser.mly
+++ b/rillc/src/parser.mly
@@ -781,6 +781,7 @@ unary_operator_as_raw:
 
 unary_pre_operator_as_raw:
                 NOT { $1 }
+        |       MINUS { $1 }
         |       TIMES { $1 }        (* deref *)
         |       BITWISE_AND { $1 }  (* address *)
 

--- a/test/compilable/unary_minus.rill
+++ b/test/compilable/unary_minus.rill
@@ -1,0 +1,13 @@
+import std.stdio;
+
+class C {
+    def operator unary-() {
+        "operator unary-\n".print();
+    }
+}
+
+def main() {
+    val mutable c = C();
+    -c;
+    return 0;
+}


### PR DESCRIPTION
The prefix operator '-' could be used but could not be defined.
So, add '-' to unary_pre_operator_as_raw of the syntax rule.